### PR TITLE
Make plugin compatible to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "npx tailwindcss -c ./tests/tailwind.config.js -i ./tests/input.css -o ./tests/output.css"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0"
+    "tailwindcss": ">=2.0.0"
   },
   "devDependencies": {
     "@fylgja/colors": "^2.0.0-beta.4",


### PR DESCRIPTION
We found that this plugin is extremely forced on Tailwind v3, even though the library functions inside index.js aren't necessarily. That's why we'd like to lower the minimum dependancy version to v2.